### PR TITLE
Install CleanAir repo on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
         name: "urbanroute"
         install:
             # Install requirements and modules
-            - pip install 'git+https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure.git@containers/cleanair'  
+            - pip install "git+https://urbanrouting-ci:$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure.git/#egg=pkg&subdirectory=containers/cleanair"
             - pip install -r requirements.txt
             # - pip install -e urbanroute
             # - pip install -e routex

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
         install:
             # Install requirements and modules
             - pip install -r requirements.txt
+            - pip install cleanair
             # - pip install -e urbanroute
             # - pip install -e routex
         script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ jobs:
         name: "urbanroute"
         install:
             # Install requirements and modules
+            - pip install https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure/tree/master/containers/cleanair.git
             - pip install -r requirements.txt
-            - pip install cleanair
             # - pip install -e urbanroute
             # - pip install -e routex
         script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
         name: "urbanroute"
         install:
             # Install requirements and modules
-            - pip install 'git+https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure/tree/master/containers/cleanair.git'
+            - pip install 'git+https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure.git@containers/cleanair'  
             - pip install -r requirements.txt
             # - pip install -e urbanroute
             # - pip install -e routex

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
         name: "urbanroute"
         install:
             # Install requirements and modules
-            - pip install https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure/tree/master/containers/cleanair.git
+            - pip install 'git+https://$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure/tree/master/containers/cleanair.git'
             - pip install -r requirements.txt
             # - pip install -e urbanroute
             # - pip install -e routex


### PR DESCRIPTION
<!-- Please follow these instructions when creating a pull request -->

<!-- 1. Ensure either the urbanroute or frontend project is selected on the right-hard-side -->
<!-- 2. Name the pull request after the issue. e.g. iss_832_add_weather_data_input ->

# Summary
<!-- Please provide an overview of what this pull request does -->
Allow install of [cleanair](https://github.com/alan-turing-institute/clean-air-infrastructure) on travis

## Type of change
<!-- Please select the types of change made -->

- [X] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] New algorithm

## Additional dependencies
<!-- List any dependencies added to the project -->


## Tests
How has the code been tested?

<!-- - Added pytest tests -->

## Issues fixes

List any issues this closes:

- Closes https://github.com/alan-turing-institute/urbanroute/issues/17

## Checklist
Please ensure you have done the following:

- [ ] Code conforms to the projects style guidelines

- [ ] New code documented using [google docstyle](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)

- [ ] Updated documentation of any changed code

- [ ] Any additional dependencies have been added to the appropriate location (e.g. `setup.py` or `requirements.txt`)

- [ ] Unit tests written and passing. Tests should prove that fix is effective or new feature works as expected

- [ ] Code needs to run on the cluster? Tag database administrator in the pull request review to configure. 

## Reviewer

Solved by (not ideal, but seemed to be the only easy way when this repo is open and cleanair is private):

- [x] Create a Gmail account
- [x] Create a new github user
- [x] Give user read permissions on cleanair repo
- [x] Create a [API Token](https://docs.travis-ci.com/user/private-dependencies/#api-token) to use on Travis for new user
- [x] Add token as travis [environment variable](https://docs.travis-ci.com/user/environment-variables/) [here](https://travis-ci.com/github/alan-turing-institute/urbanroute/settings)
- [x] Install on travis with `pip install "git+https://urbanrouting-ci:$CLEANAIRTOKEN@github.com/alan-turing-institute/clean-air-infrastructure.git/#egg=pkg&subdirectory=containers/cleanair"`